### PR TITLE
Fortran wrapper for otter-serial with fibonnaci example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ set_property(TARGET otter-events-ompt PROPERTY POSITION_INDEPENDENT_CODE ON)
 # Serial event source
 add_library(otter-events-serial OBJECT
     ${CMAKE_CURRENT_SOURCE_DIR}/src/otter/events/serial/otter-serial.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/otter/events/serial/otter-serial.F90
     ${CMAKE_CURRENT_SOURCE_DIR}/src/otter/types/otter-structs.c
 )
 target_include_directories(otter-events-serial PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/include/otter/otter-serial.F90
+++ b/include/otter/otter-serial.F90
@@ -1,0 +1,8 @@
+#define fortran_otterTraceInitialise() fortran_otterTraceInitialise_i(__FILE__, "FORTRAN_FUNCTION", __LINE__)
+#define fortran_otterParallelBegin() fortran_otterParallelBegin_i(__FILE__, "FORTRAN_FUNCTION", __LINE__)
+#define fortran_otterTaskBegin() fortran_otterTaskBegin_i(__FILE__, "FORTRAN_FUNCTION", __LINE__)
+#define fortran_otterTaskSingleBegin() fortran_otterTaskSingleBegin_i(__FILE__, "FORTRAN_FUNCTION", __LINE__)
+#define fortran_otterLoopBegin() fortran_otterLoopBegin_i(__FILE__, "FORTRAN_FUNCTION", __LINE__)
+#define fortran_otterLoopIterationBegin() fortran_otterLoopIterationBegin_i(__FILE__, "FORTRAN_FUNCTION", __LINE__)
+#define fortran_otterSynchroniseChildTasks() fortran_otterSynchroniseChildTasks_i(__FILE__, "FORTRAN_FUNCTION", __LINE__)
+#define fortran_otterSynchroniseDescendantTasksBegin() fortran_otterSynchroniseDescendantTasksBegin_i(__FILE__, "FORTRAN_FUNCTION", __LINE__)

--- a/src/otter/events/serial/otter-serial.F90
+++ b/src/otter/events/serial/otter-serial.F90
@@ -1,0 +1,220 @@
+module otter_serial
+
+    contains
+
+    subroutine fortran_otterTraceInitialise_i(filename, functionname, linenum)
+        use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        interface
+            subroutine otterTraceInitialise_i(filename, functionname, linenum) bind(C, NAME="otterTraceInitialise_i")
+                use, intrinsic :: iso_c_binding
+                character(len=1, kind=c_char), dimension(*), intent(in) :: filename, functionname
+                integer(c_int), value :: linenum
+            end subroutine otterTraceInitialise_i
+        end interface
+        call otterTraceInitialise_i(trim(filename)//char(0), trim(functionname)//char(0), Int(linenum, kind=c_int))
+    end subroutine fortran_otterTraceInitialise_i
+    
+    subroutine fortran_otterTraceFinalise()
+        interface
+            subroutine otterTraceFinalise() bind(C, NAME="otterTraceFinalise")
+            end subroutine
+        end interface
+        call otterTraceFinalise()
+    end subroutine fortran_otterTraceFinalise
+    
+    subroutine fortran_otterParallelBegin_i(filename, functionname, linenum)
+        use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        interface
+            subroutine otterParallelBegin_i(filename, functionname, linenum) bind(C, NAME="otterParallelBegin_i")
+                use, intrinsic :: iso_c_binding
+                character(len=1, kind=c_char), dimension(*), intent(in) :: filename, functionname
+                integer(c_int), value :: linenum
+            end subroutine otterParallelBegin_i
+        end interface
+        call otterParallelBegin_i(trim(filename)//char(0), trim(functionname)//char(0), Int(linenum, kind=c_int))
+    end subroutine fortran_otterParallelBegin_i
+    
+    subroutine fortran_otterParallelEnd()
+        use, intrinsic :: iso_c_binding
+        interface
+            subroutine otterParallelEnd() bind(C, NAME="otterParallelEnd")
+            end subroutine
+        end interface
+    
+        call otterParallelEnd()
+    
+    end subroutine
+    
+    subroutine fortran_otterTaskBegin_i(filename, functionname, linenum)
+        use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        interface
+            subroutine otterTaskBegin_i(filename, functionname, linenum) bind(C, NAME="otterTaskBegin_i")
+                use, intrinsic :: iso_c_binding
+                character(len=1, kind=c_char), dimension(*), intent(in) :: filename, functionname
+                integer(c_int), value :: linenum
+            end subroutine otterTaskBegin_i
+        end interface
+    
+        call otterTaskBegin_i(trim(filename)//char(0), trim(functionname)//char(0), Int(linenum, kind=c_int))
+    end subroutine fortran_otterTaskBegin_i
+    
+    subroutine fortran_otterTaskEnd()
+        use, intrinsic :: iso_c_binding
+        interface
+            subroutine otterTaskEnd() bind(C, NAME="otterTaskEnd")
+            end subroutine otterTaskEnd
+        end interface
+    
+        call otterTaskEnd()
+    end subroutine fortran_otterTaskEnd
+    
+    
+    subroutine fortran_otterTaskSingleBegin_i(filename, functionname, linenum)
+        use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        interface
+            subroutine otterTaskSingleBegin_i(filename, functionname, linenum) bind(C, NAME="otterTaskSingleBegin_i")
+                use, intrinsic :: iso_c_binding
+                character(len=1, kind=c_char), dimension(*), intent(in) :: filename, functionname
+                integer(c_int), value :: linenum
+            end subroutine otterTaskSingleBegin_i
+        end interface
+    
+        call otterTaskSingleBegin_i(trim(filename)//char(0), trim(functionname)//char(0), Int(linenum, kind=c_int))
+    end subroutine fortran_otterTaskSingleBegin_i
+    
+    subroutine fortran_otterTaskSingleEnd()
+        use, intrinsic :: iso_c_binding
+        interface
+            subroutine otterTaskSingleEnd() bind(C, NAME="otterTaskSingleEnd")
+            end subroutine
+        end interface
+    
+        call otterTaskSingleEnd()
+     end subroutine fortran_otterTaskSingleEnd
+    
+    subroutine fortran_otterLoopBegin_i(filename, functionname, linenum)
+        use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        interface
+            subroutine otterLoopBegin_i(filename, functionname, linenum) bind(C, NAME="otterLoopBegin_i")
+                use, intrinsic :: iso_c_binding
+                character(len=1, kind=c_char), dimension(*), intent(in) :: filename, functionname
+                integer(c_int), value :: linenum
+            end subroutine otterLoopBegin_i
+        end interface
+        call otterLoopBegin_i(trim(filename)//char(0), trim(functionname)//char(0), Int(linenum, kind=c_int))
+    end subroutine fortran_otterLoopBegin_i
+    
+    subroutine fortran_otterLoopEnd()
+        use, intrinsic :: iso_c_binding
+        
+        interface
+            subroutine otterLoopEnd() bind(C, NAME="otterLoopEnd")
+                use, intrinsic :: iso_c_binding
+            end subroutine otterLoopEnd
+        end interface
+    
+        call otterLoopEnd()
+    end subroutine
+    
+    subroutine fortran_otterLoopIterationBegin_i(filename, functionname, linenum)
+        use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        interface
+            subroutine otterLoopIterationBegin_i(filename, functionname, linenum) bind(C, NAME="otterLoopIterationBegin_i")
+                use, intrinsic :: iso_c_binding
+                character(len=1, kind=c_char), dimension(*), intent(in) :: filename, functionname
+                integer(c_int), value :: linenum
+            end subroutine otterLoopIterationBegin_i
+        end interface
+        call otterLoopIterationBegin_i(trim(filename)//char(0), trim(functionname)//char(0), Int(linenum, kind=c_int))
+    end subroutine fortran_otterLoopIterationBegin_i
+    
+    subroutine fortran_otterLoopIterationEnd()
+        use, intrinsic :: iso_c_binding
+        
+        interface
+            subroutine otterLoopIterationEnd() bind(C, NAME="otterLoopIterationEnd")
+                use, intrinsic :: iso_c_binding
+            end subroutine otterLoopIterationEnd
+        end interface
+    
+        call otterLoopIterationEnd()
+    end subroutine
+    
+    subroutine fortran_otterSynchroniseChildTasks_i(filename, functionname, linenum)
+        use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        interface
+            subroutine otterSynchroniseChildTasks_i(filename, functionname, linenum) bind(C, NAME="otterSynchroniseChildTasks_i")
+                use, intrinsic :: iso_c_binding
+                character(len=1, kind=c_char), dimension(*), intent(in) :: filename, functionname
+                integer(c_int), value :: linenum
+            end subroutine otterSynchroniseChildTasks_i
+        end interface
+        call otterSynchroniseChildTasks_i(trim(filename)//char(0), trim(functionname)//char(0), Int(linenum, kind=c_int))
+    
+    end subroutine fortran_otterSynchroniseChildTasks_i
+    
+    subroutine fortran_otterSynchroniseDescendantTasksBegin_i(filename, functionname, linenum)
+        use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        interface
+            subroutine otterSynchroniseDescendantTasksBegin_i(filename, functionname, linenum)&
+                    bind(C, NAME="otterSynchroniseDescendantTasksBegin_i")
+                use, intrinsic :: iso_c_binding
+                character(len=1, kind=c_char), dimension(*), intent(in) :: filename, functionname
+                integer(c_int), value :: linenum
+            end subroutine otterSynchroniseDescendantTasksBegin_i
+        end interface
+        call otterSynchroniseDescendantTasksBegin_i(trim(filename)//char(0), trim(functionname)//char(0), Int(linenum, kind=c_int))
+    end subroutine fortran_otterSynchroniseDescendantTasksBegin_i
+    
+    subroutine fortran_otterSynchroniseDescendantTasksEnd()
+        use, intrinsic :: iso_c_binding
+        interface
+            subroutine otterSynchroniseDescendantTasksEnd() bind(C, NAME="otterSynchroniseDescendantTasksEnd")
+            end subroutine
+        end interface
+        call otterSynchroniseDescendantTasksEnd()
+    end subroutine fortran_otterSynchroniseDescendantTasksEnd
+    
+    subroutine fortran_otterTraceStart()
+        use, intrinsic :: iso_c_binding
+        interface
+            subroutine otterTraceStart() bind(C, NAME="otterTraceStart")
+            end subroutine otterTraceStart
+        end interface
+        call otterTraceStart()
+    end subroutine fortran_otterTraceStart
+    
+    subroutine fortran_otterTraceStop()
+        use, intrinsic :: iso_c_binding
+        interface
+            subroutine otterTraceStop() bind(C, NAME="otterTraceStop")
+            end subroutine otterTraceStop
+        end interface
+        call otterTraceStop()
+    end subroutine fortran_otterTraceStop
+
+end module otter_serial

--- a/src/otter/examples/otter-serial-fib.F90
+++ b/src/otter/examples/otter-serial-fib.F90
@@ -1,0 +1,63 @@
+#include "otter-serial.F90"
+
+Integer Recursive Function fib(n) result(a)
+    use otter_serial
+    Implicit None
+    Integer, Intent(in) :: n
+    Integer :: i, j
+
+    if (n < 2) then
+        a = n
+    else
+        ! Tag: wrap a task
+        Call fortran_otterTaskBegin()
+        i = fib(n-1)
+        Call fortran_otterTaskEnd()
+
+        ! Tag: wrap a task
+        Call fortran_otterTaskBegin()
+        j = fib(n-2)
+        Call fortran_otterTaskEnd()
+
+        ! Indicate a synchronisation constraint on a subset of work items
+        Call fortran_otterSynchroniseChildTasks()
+
+        a = i + j
+    end if
+End Function fib
+
+
+Program fibonacci
+    use otter_serial
+    Implicit None
+    Integer :: n, argc
+    Integer :: fibn
+    Integer, External :: fib
+    Character(len=32) :: arg
+
+    argc = command_argument_count()
+    if (argc /= 1) then
+        print *, "Provide one integer argument to the program (n)"
+        STOP
+    end if
+
+    call get_command_argument(1, value=arg)
+    read(arg(1:len(arg)),*) n
+
+    Call fortran_otterTraceInitialise()
+
+    ! Tag: start of a region we want to parallelise
+    Call fortran_otterParallelBegin()
+
+    ! Tag: wrap a task
+    Call fortran_otterTaskSingleBegin()
+    fibn = fib(n)
+    Call fortran_otterTaskSingleEnd()
+
+    Call fortran_otterParallelEnd()
+
+    print *, n, fibn
+
+    Call fortran_otterTraceFinalise()
+
+End Program fibonacci


### PR DESCRIPTION
Hi Adam,

Ok, now I'm working from the correct base!

The current structure of the code is the following files:

- `include/otter/otter-serial.F90` - this is a set of preprocessor macros for using the defined functions. These need to be included in any fortran program using `#include`. Must be visible on the include path (i.e. `-Iinclude/otter`).
- `src/otter/events/serial/otter-serial.F90` - this contains the module to call the C code from Fortran. Rather than overlap the names, they have their own names in Fortran, which are fortran_otterBaseName. This file is added in the the `add_library(otter-events-serial` part of the CMakeLists, and the resulting output is a otter_serial.mod file which also needs to be visible on the -I path in any building from Fortran. It is used by use otter_serial from a Fortran Program/subroutine/etc.
- `src/otter/examples/otter-serial-fib.F90` - this contains the example fibonacci example, with no automatic compilation so far. On my machine (from the otter root directory), I can build it with: `gfortran -std=f2003 src/otter/examples/otter-serial-fib.F90 -Iinclude/otter/ -Lbuild/lib/ -lotter-serial -Ibuild`, and the output I get is as follows:
```
[achalk@glados otter]$ ./a.out 4
[i] [otterTraceInitialise_i          ] Otter environment variables:
[i] [otterTraceInitialise_i          ] host                           glados.dl.ac.uk
[i] [otterTraceInitialise_i          ] OTTER_TRACE_PATH               trace
[i] [otterTraceInitialise_i          ] OTTER_TRACE_NAME               otter_trace
[i] [otterTraceInitialise_i          ] OTTER_APPEND_HOSTNAME          No
Trace output path:             trace/otter_trace.3908223
[d] [otterTraceInitialise_i          ] src/otter/examples/otter-serial-fib.F90:47 in FORTRAN_FUNCTION
[d] [otterParallelBegin_i            ] src/otter/examples/otter-serial-fib.F90:50 in FORTRAN_FUNCTION
[d] [otterTaskSingleBegin_i          ] src/otter/examples/otter-serial-fib.F90:53 in FORTRAN_FUNCTION
[d] [otterTaskBegin_i                ] src/otter/examples/otter-serial-fib.F90:13 in FORTRAN_FUNCTION
[d] [otterTaskBegin_i                ] src/otter/examples/otter-serial-fib.F90:13 in FORTRAN_FUNCTION
[d] [otterTaskBegin_i                ] src/otter/examples/otter-serial-fib.F90:13 in FORTRAN_FUNCTION
[d] [otterTaskBegin_i                ] src/otter/examples/otter-serial-fib.F90:18 in FORTRAN_FUNCTION
[d] [otterSynchroniseChildTasks_i    ] src/otter/examples/otter-serial-fib.F90:23 in FORTRAN_FUNCTION
[d] [otterTaskBegin_i                ] src/otter/examples/otter-serial-fib.F90:18 in FORTRAN_FUNCTION
[d] [otterSynchroniseChildTasks_i    ] src/otter/examples/otter-serial-fib.F90:23 in FORTRAN_FUNCTION
[d] [otterTaskBegin_i                ] src/otter/examples/otter-serial-fib.F90:18 in FORTRAN_FUNCTION
[d] [otterTaskBegin_i                ] src/otter/examples/otter-serial-fib.F90:13 in FORTRAN_FUNCTION
[d] [otterTaskBegin_i                ] src/otter/examples/otter-serial-fib.F90:18 in FORTRAN_FUNCTION
[d] [otterSynchroniseChildTasks_i    ] src/otter/examples/otter-serial-fib.F90:23 in FORTRAN_FUNCTION
[d] [otterSynchroniseChildTasks_i    ] src/otter/examples/otter-serial-fib.F90:23 in FORTRAN_FUNCTION
           4           3
OTTER_TRACE_FOLDER=/home/achalk/otter/trace/otter_trace.3908223
```
I haven't inspected the trace/am not quite sure how to do that with the changes in Otter right now, so I'll focus on fixing up the commit and then we can double check the output.

Regarding the .mod file - I feel like there must be a way to have this appear in the include directory, but I am not good with CMake so I'm not sure how to do that.