### PR TITLE
New Fortran bindings

### DIFF
--- a/include/api/otter-task-graph/otter-task-graph.h
+++ b/include/api/otter-task-graph/otter-task-graph.h
@@ -61,8 +61,8 @@ typedef enum {
  *
  */
 typedef enum otter_add_to_pool_t {
-  otter_no_add_to_pool,
-  otter_add_to_pool
+  otter_no_add_to_pool = 0,
+  otter_add_to_pool = 1
 } otter_add_to_pool_t;
 
 #ifdef __cplusplus

--- a/src/otter-task-graph/CMakeLists.txt
+++ b/src/otter-task-graph/CMakeLists.txt
@@ -3,6 +3,7 @@ include(GNUInstallDirs)
 # Provide the otter-task-graph library
 add_library(otter-task-graph
     otter-task-graph.c
+    otter-task-graph.F90
 )
 
 target_include_directories(otter-task-graph
@@ -42,3 +43,5 @@ install(EXPORT otter-task-graph-target
     FILE OtterTaskGraph.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Otter
 )
+
+install(FILES ${CMAKE_BINARY_DIR}/lib/fmod/otter_task_graph.mod DESTINATION include/otter)

--- a/src/otter-task-graph/otter-task-graph.F90
+++ b/src/otter-task-graph/otter-task-graph.F90
@@ -1,28 +1,47 @@
 module otter_task_graph
     enum, bind(c)
-        enumerator otter_sync_children
-        enumerator otter_sync_descendants
+        enumerator :: otter_no_add_to_pool = 0
+        enumerator :: otter_add_to_pool = 1
     end enum
+
+    enum, bind(c)
+        enumerator :: otter_endpoint_enter = 0,
+        enumerator :: otter_endpoint_leave = 1,
+        enumerator :: otter_endpoint_discrete = 2
+    end enum
+
     contains
 
-    subroutine fortran_otterTraceInitialise()
+    subroutine fortran_otterTraceInitialise(filename, functionname, linenum)
         use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        type(c_ptr) :: source_location
         interface
-            subroutine otterTraceInitialise() bind(C, NAME="otterTraceInitialise")
+            subroutine otterTraceInitialise(source_location) bind(C, NAME="otterTraceInitialise")
                 use, intrinsic :: iso_c_binding
+                type(c_ptr), value :: source_location
             end subroutine otterTraceInitialise
         end interface
-        call otterTraceInitialise()
+        !TODO call method to compres filename/funcanem/linenum into opaque pointer
+        call otterTraceInitialise(source_location)
     end subroutine fortran_otterTraceInitialise
 
-    subroutine fortran_otterTraceFinalise()
+    subroutine fortran_otterTraceFinalise(filename, functionname, linenum)
         use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        type(c_ptr) :: source_location
         interface
-            subroutine otterTraceFinalise() bind(C, NAME="otterTraceFinalise")
+            subroutine otterTraceFinalise(source_location) bind(C, NAME="otterTraceFinalise")
                 use, intrinsic :: iso_c_binding
+                type(c_ptr), value:: source_location
             end subroutine
         end interface
-        call otterTraceFinalise()
+        !TODO call method to compres filename/funcanem/linenum into opaque pointer
+        call otterTraceFinalise(source_location)
     end subroutine fortran_otterTraceFinalise
 
     subroutine fortran_otterTraceStart()
@@ -45,80 +64,201 @@ module otter_task_graph
        call otterTraceStop()
    end subroutine fortran_otterTraceStop
 
-   type(c_ptr) function fortran_otterTaskBegin_i(filename, functionname, linenum, parent_task)
+   type(c_ptr) function fortran_otterTaskInitialise_i(parent_task, flavour, add_to_pool, record_task_create_event, &
+                                                      filename, functionname, linenum, tag)
         use, intrinsic :: iso_c_binding
         character(len = *) :: filename
         character(len = *) :: functionname
         integer :: linenum
         type(c_ptr) :: parent_task
+        Integer :: flavour
+        Integer :: add_to_pool
+        Logical(c_bool) :: record_task_create_event
+        character(len = *) :: tag
+        type(c_ptr) :: source_location
         interface
-            type(c_ptr) function otterTaskBegin(filename, functionname, linenum, parent_task) bind(C, NAME="otterTaskBegin")
+            ! TODO
+            type(c_ptr) function otterTaskInitialise(parent_task, flavour, add_to_pool, record_task_create_event, &
+                                                     source_location, tag) bind(C, NAME="otterTaskInitialise")
                 use, intrinsic :: iso_c_binding
-                character(len=1, kind=c_char), dimension(*), intent(in) :: filename, functionname
-                integer(c_int), value :: linenum
                 type(c_ptr), value :: parent_task
-            end function otterTaskBegin
+                Integer(c_int), value :: flavour
+                Integer(c_int), value :: add_to_pool
+                Logical(c_bool), value :: record_task_create_event
+                character(len=1, kind=c_char), dimension(*), intent(in) :: tag
+                type(c_ptr), value :: source_location
+               
+            end function otterTaskInitialise
         end interface
-        fortran_otterTaskBegin_i = otterTaskBegin(trim(filename), trim(functionname), Int(linenum, kind=c_int), parent_task)
-    end function fortran_otterTaskBegin_i
+        !TODO call method to compres filename/funcanem/linenum into opaque pointer
+        fortran_otterTaskInitialise_i = otterTaskInitialise(parent_task, Int(flavour, kind=c_int), Int(add_to_pool, kind=c_int),&
+                                                            record_task_create_event, &
+                                                            source_location, trim(tag))
+    end function fortran_otterTaskInitialise_i
 
-    subroutine fortran_otterTaskEnd(task)
+    subroutine fortran_otterTaskCreate(task, parent_task, filename, functionname, linenum)
         use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
         type(c_ptr) :: task
+        type(c_ptr) :: parent_task
+        type(c_ptr) :: source_location
         interface
-            subroutine otterTaskEnd(task) bind(C, NAME="otterTaskEnd")
+            subroutine otterTaskCreate(task, parent_task, source_location) bind(C, NAME="otterTaskCreate")
                 use, intrinsic :: iso_c_binding
                 type(c_ptr), value :: task
+                type(c_ptr), value :: parent_task
+                type(c_ptr), value :: source_location
+            end subroutine otterTaskCreate
+        end interface
+        !TODO call method to compres filename/funcanem/linenum into opaque pointer
+        call otterTaskCreate(task, parent_task, source_location)
+    end subroutine fortran_otterTaskCreate
+
+    subroutine fortran_otterTaskStart(task, filename, functionname, linenum)
+        use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        type(c_ptr) :: task
+        type(c_ptr) :: source_location
+        interface
+            subroutine otterTaskStart(task, start_location) bind(C, NAME="otterTaskStart")
+                use, intrinsic :: iso_c_binding
+                type(c_ptr), value :: task
+                type(c_ptr), value :: start_location
+            end subroutine otterTaskStart
+        end interface
+        !TODO call method to compres filename/funcanem/linenum into opaque pointer
+        call otterTaskStart(task, source_location)
+    end subroutine fortran_otterTaskStart
+
+    subroutine fortran_otterTaskEnd(task, filename, functionname, linenum)
+        use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        type(c_ptr) :: task
+        type(c_ptr) :: source_location
+        interface
+            subroutine otterTaskEnd(task, stop_location) bind(C, NAME="otterTaskEnd")
+                use, intrinsic :: iso_c_binding
+                type(c_ptr), value :: task
+                type(c_ptr), value :: stop_location
             end subroutine
         end interface
-        call otterTaskEnd(task)
+        !TODO call method to compres filename/funcanem/linenum into opaque pointer
+        call otterTaskEnd(task, source_location)
     end subroutine fortran_otterTaskEnd
 
-    subroutine fortran_otterSynchroniseTasks(task, mode)
+    subroutine fortran_otterTaskPushLabel(task, label)
+        use, intrinsic :: iso_c_binding
+        type(c_ptr) :: task
+        character(len = *) :: label
+
+        interface
+            subroutine otterNotYetImplemented(task, label) bind(C, NAME="NYI")
+                type(c_ptr), value :: task
+                character(len=1, kind=c_char), dimension(*), intent(in) :: label
+            end subroutine
+        end interface
+        call otterNYI(task, trim(label))
+    end subroutine fortran_otterTaskPushLabel
+
+
+    function type(c_ptr) fortran_otterTaskPopLabel(label)
+        use, intrinsic :: iso_c_binding
+        character(len = *) :: label
+
+        interface
+            function type(c_ptr) otterNYI(label) bind(C, NAME=NYI)
+                character(len=1, kind=c_char), dimension(*), intent(in) :: label
+            end function
+        end interface
+        call otterNYI(trim(label))
+    end function fortran_otterTaskPopLabel
+
+
+    function type(c_ptr) fortran_otterTaskBorrowLabel(label)
+        use, intrinsic :: iso_c_binding
+        character(len = *) :: label
+
+        interface
+            function type(c_ptr) otterNYI(label) bind(C, NAME=NYI)
+                character(len=1, kind=c_char), dimension(*), intent(in) :: label
+            end function
+        end interface
+        call otterNYI(trim(label))
+    end function fortran_otterTaskBorrowLabel
+
+
+
+    subroutine fortran_otterSynchroniseTasks(task, mode, endpoint)
         use, intrinsic :: iso_c_binding
         type(c_ptr) :: task
         integer :: mode
+        integer :: endpoint
         interface
-            subroutine otterSynchroniseTasks(task, mode) bind(C, NAME="otterSynchroniseTasks")
+            subroutine otterSynchroniseTasks(task, mode, endpoint) bind(C, NAME="otterSynchroniseTasks")
                 use, intrinsic :: iso_c_binding
                 type(c_ptr), value :: task
                 integer(c_int), value :: mode
+                integer(c_int), value :: endpoint
             end subroutine otterSynchroniseTasks
         end interface
-        call otterSynchroniseTasks(task, Int(mode, kind=c_int))
+        call otterSynchroniseTasks(task, Int(mode, kind=c_int), Int(endpoint, kind=c_int))
     end subroutine fortran_otterSynchroniseTasks
 
-    subroutine fortran_otterPhaseBegin(phase_name)
+    subroutine fortran_otterPhaseBegin(phase_name, filename, functionname, linenum)
         use, intrinsic :: iso_c_binding
         character(len = *) :: phase_name
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        type(c_ptr) :: source_location
         interface
-            subroutine otterPhaseBegin(phase_name) bind(C, NAME="otterPhaseBegin")
+            subroutine otterPhaseBegin(phase_name, source_location) bind(C, NAME="otterPhaseBegin")
                 use, intrinsic :: iso_c_binding
                 character(len=1, kind=c_char), dimension(*), intent(in) :: phase_name
+                type(c_ptr), value :: source_location
             end subroutine otterPhaseBegin
         end interface
-        call otterPhaseBegin(trim(phase_name))
+        !TODO call method to compres filename/funcanem/linenum into opaque pointer
+        call otterPhaseBegin(trim(phase_name), source_location)
     end subroutine fortran_otterPhaseBegin
 
-    subroutine fortran_otterPhaseEnd()
+    subroutine fortran_otterPhaseEnd(filename, functionname, linenum)
         use, intrinsic :: iso_c_binding
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        type(c_ptr) :: source_location
         interface
-            subroutine otterPhaseEnd() bind(C, NAME="otterPhaseEnd")
+            subroutine otterPhaseEnd(source_location) bind(C, NAME="otterPhaseEnd")
                 use, intrinsic :: iso_c_binding
+                type(c_ptr), value :: source_location
             end subroutine
        end interface
-       call otterPhaseEnd()
+        !TODO call method to compres filename/funcanem/linenum into opaque pointer
+       call otterPhaseEnd(source_location)
     end subroutine fortran_otterPhaseEnd
 
-    subroutine fortran_otterPhaseSwitch(phase_name)
+    subroutine fortran_otterPhaseSwitch(phase_name, filename, functionname, linenum)
         use, intrinsic :: iso_c_binding
         character(len = *) :: phase_name
+        character(len = *) :: filename
+        character(len = *) :: functionname
+        integer :: linenum
+        type(c_ptr) :: source_location
         interface
-            subroutine otterPhaseSwitch(phase_name) bind(C, NAME="otterPhaseSwitch")
+            subroutine otterPhaseSwitch(phase_name, source_location) bind(C, NAME="otterPhaseSwitch")
                 use, intrinsic :: iso_c_binding
                 character(len=1, kind=c_char), dimension(*), intent(in) :: phase_name
+                type(c_ptr), value :: source_location
             end subroutine otterPhaseSwitch
        end interface
-       call otterPhaseSwitch(trim(phase_name))
+        !TODO call method to compres filename/funcanem/linenum into opaque pointer
+       call otterPhaseSwitch(trim(phase_name), source_location)
    end subroutine fortran_otterPhaseSwitch
 end module otter_task_graph

--- a/src/otter-task-graph/otter-task-graph.F90
+++ b/src/otter-task-graph/otter-task-graph.F90
@@ -1,13 +1,13 @@
 module otter_task_graph
     enum, bind(c)
-        enumerator :: otter_no_add_to_pool = 0
-        enumerator :: otter_add_to_pool = 1
+        enumerator :: otter_no_add_to_pool
+        enumerator :: otter_add_to_pool
     end enum
 
     enum, bind(c)
-        enumerator :: otter_endpoint_enter = 0,
-        enumerator :: otter_endpoint_leave = 1,
-        enumerator :: otter_endpoint_discrete = 2
+        enumerator :: otter_endpoint_enter
+        enumerator :: otter_endpoint_leave
+        enumerator :: otter_endpoint_discrete
     end enum
 
     interface
@@ -110,7 +110,7 @@ module otter_task_graph
             end function otterTaskInitialise
         end interface
         source_location = fortran_otterCreateSourceArgs(trim(filename), trim(functionname), Int(linenum, Kind=c_int))
-        fortran_otterTaskInitialise_i = otterTaskInitialise(parent_task, Int(flavour, kind=c_int), Int(add_to_pool, kind=c_int),&
+        fortran_otterTaskInitialise = otterTaskInitialise(parent_task, Int(flavour, kind=c_int), Int(add_to_pool, kind=c_int),&
                                                             record_task_create_event, &
                                                             source_location, trim(tag))
         call fortran_otterFreeSourceArgs(source_location)
@@ -149,12 +149,12 @@ module otter_task_graph
                 use, intrinsic :: iso_c_binding
                 type(c_ptr), value :: task
                 type(c_ptr), value :: start_location
-            end subroutine otterTaskStart
+            end function otterTaskStart
         end interface
         source_location = fortran_otterCreateSourceArgs(trim(filename), trim(functionname), Int(linenum, Kind=c_int))
         fortran_otterTaskStart = otterTaskStart(task, source_location)
         call fortran_otterFreeSourceArgs(source_location)
-    end subroutine fortran_otterTaskStart
+    end function fortran_otterTaskStart
 
     subroutine fortran_otterTaskEnd(task, filename, functionname, linenum)
         use, intrinsic :: iso_c_binding
@@ -181,6 +181,7 @@ module otter_task_graph
         character(len = *) :: label
         interface
             subroutine otterTaskPushLabel(task, label) bind(C, NAME="otterTaskPushLabel_f")
+                use, intrinsic :: iso_c_binding
                 type(c_ptr), value :: task
                 character(len=1, kind=c_char), dimension(*), intent(in) :: label
             end subroutine
@@ -194,7 +195,8 @@ module otter_task_graph
         character(len = *) :: label
 
         interface
-            function type(c_ptr) otterTaskPopLabel(label) bind(C, NAME="otterTaskPopLabel_f")
+            type(c_ptr) function otterTaskPopLabel(label) bind(C, NAME="otterTaskPopLabel_f")
+                use, intrinsic :: iso_c_binding
                 character(len=1, kind=c_char), dimension(*), intent(in) :: label
             end function
         end interface
@@ -206,7 +208,8 @@ module otter_task_graph
         use, intrinsic :: iso_c_binding
         character(len = *) :: label
         interface
-            function type(c_ptr) otterTaskBorrowLabel(label) bind(C, NAME="otterTaskBorrowLabel_f")
+            type(c_ptr) function otterTaskBorrowLabel(label) bind(C, NAME="otterTaskBorrowLabel_f")
+                use, intrinsic :: iso_c_binding
                 character(len=1, kind=c_char), dimension(*), intent(in) :: label
             end function
         end interface

--- a/src/otter-task-graph/otter-task-graph.c
+++ b/src/otter-task-graph/otter-task-graph.c
@@ -92,9 +92,9 @@ otter_source_args* otterCreateSourceArgs(const char *filename,
                                          const char *function,
                                          int linenum){
     otter_source_args *source_arg = malloc(sizeof(otter_source_args));
-    otter_source_args->file = filename;
-    otter_source_args->func = function;
-    otter_source_args->line = linenum;
+    source_arg->file = filename;
+    source_arg->func = function;
+    source_arg->line = linenum;
 
     return source_arg;
 }


### PR DESCRIPTION
I've changed the existing fortran bindings to fit a structure akin to the new C API.

Notably there are 2 limitations at the moment:
1. No support for variadic functions in Fortran. We'll need non-variadic C functions to call (which can just be wrappers for the main C functions).
2. No implementation of `otter_source_args` in Fortran - and no functions that take a pointer to the structure. We need either to thus implement the structure in Fortran (which may be tricky because of the strings, but maybe they can be opaque pointers in Fortran code), or have a C wrapper that creates a pointer to the structure in Fortran from arguments, and have C functions that take a pointer to the structure instead of the structure itself (again, basic wrapper functions calling the real function).

@adamtuft do you have a preferred approach? Am happy to work on and implement either if you're busy as well.